### PR TITLE
fix: filter towns by postal code

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -1,3 +1,4 @@
 {
-  "ville": "Montpellier"
+  "ville": "Montpellier",
+  "code_postal": "34000"
 }


### PR DESCRIPTION
Le nom de commune seul ne suffit pas car certaines communes portent strictement le même nom. 
J'ai donc ajouté le code postal en plus. Avec ces deux propriétés on garantit de trouver un résultat unique et correct.